### PR TITLE
chore(node): disable to-pdf CLI and batch pdf options, document for later

### DIFF
--- a/documents/docs/guide/cli.mdx
+++ b/documents/docs/guide/cli.mdx
@@ -295,6 +295,7 @@ npx @ohah/hwpjs <command>
 ## 참고사항
 
 - CLI는 Node.js 환경에서만 작동합니다.
+- **PDF 변환 (`to-pdf`, `batch --format pdf`)**: 코어/NAPI에는 PDF 변환 API가 구현되어 있으나, CLI에서는 아직 비활성화되어 있습니다. 추후 구현이 정리되면 `to-pdf` 명령 및 batch의 `--format pdf`, `--font-dir`, `--no-embed-images` 옵션을 활성화할 예정입니다.
 - 모든 명령어는 `--help` 옵션으로 상세한 도움말을 볼 수 있습니다.
 - 출력 파일이 이미 존재하는 경우 덮어씌워집니다.
 - 배치 변환 시 오류가 발생한 파일은 스킵되고 계속 진행됩니다.

--- a/documents/plans/2025-02-21-pdf-viewer.md
+++ b/documents/plans/2025-02-21-pdf-viewer.md
@@ -267,6 +267,8 @@ git commit -m "feat(core): iterate all body paragraphs in PDF export"
 
 이 항목들은 MVP 이후 별도 태스크로 쪼개어 진행하는 것을 권장.
 
+**CLI 비활성화:** 현재 `to-pdf` 명령과 batch의 `--format pdf`·`--font-dir`·`--no-embed-images`는 코드는 두고 주석 처리하여 비활성화해 두었습니다. 추후 구현이 정리되면 해당 주석을 해제해 활성화할 예정입니다. 문서는 [CLI 가이드](../docs/guide/cli.mdx) 참고사항에 동일 내용을 적어 두었습니다.
+
 ---
 
 **테스트·폰트:** 테스트에서는 `tests/fixtures/fonts/`에 폰트 번들을 두고 `find_font_dir()`를 사용하면 자동으로 폰트 경로를 잡을 수 있다.

--- a/packages/hwpjs/src-cli/index.ts
+++ b/packages/hwpjs/src-cli/index.ts
@@ -4,7 +4,8 @@ import { Command } from 'commander';
 import { toJsonCommand } from './commands/to-json';
 import { toMarkdownCommand } from './commands/to-markdown';
 import { toHtmlCommand } from './commands/to-html';
-import { toPdfCommand } from './commands/to-pdf';
+// to-pdf 비활성화 (확장만 해둠)
+// import { toPdfCommand } from './commands/to-pdf';
 import { infoCommand } from './commands/info';
 import { extractImagesCommand } from './commands/extract-images';
 import { batchCommand } from './commands/batch';
@@ -17,7 +18,7 @@ program.name('hwpjs').description('HWP file parser CLI').version('0.1.0-rc.4');
 toJsonCommand(program);
 toMarkdownCommand(program);
 toHtmlCommand(program);
-toPdfCommand(program);
+// toPdfCommand(program);
 infoCommand(program);
 extractImagesCommand(program);
 batchCommand(program);


### PR DESCRIPTION
# chore(node): disable to-pdf CLI and batch pdf options, document for later

## Purpose

- PDF 변환은 코어/NAPI에만 구현되어 있고, CLI는 확장만 해 둔 상태이므로 to-pdf 명령과 batch의 PDF 관련 옵션을 비활성화합니다.
- 추후 구현이 정리되면 활성화할 예정임을 문서와 계획에 적어 둡니다.

## Work content

- **CLI 비활성화 (주석 처리)**  
  - `packages/hwpjs/src-cli/index.ts`: `toPdfCommand` import 및 등록 주석 처리.  
  - `packages/hwpjs/src-cli/commands/batch.ts`: `toPdf` require·`getDefaultFontDir`·`--format pdf`·`--font-dir`·`--no-embed-images` 및 pdf 분기 로직을 주석 처리. `--format pdf` 사용 시 "PDF format is currently disabled." 메시지 후 종료.
- **문서**  
  - `documents/docs/guide/cli.mdx`: 참고사항에 "PDF 변환(to-pdf, batch --format pdf)은 현재 비활성화, 추후 구현 정리 후 활성화 예정" 문구 추가.  
  - `documents/plans/2025-02-21-pdf-viewer.md`: Task 6 아래에 CLI 비활성화 설명 및 CLI 가이드 참고 링크 추가.

## How to test

- `hwpjs --help`에 `to-pdf` 명령이 보이지 않는지 확인.
- `hwpjs batch ./dir -o ./out --format pdf` 실행 시 "PDF format is currently disabled." 출력 후 종료하는지 확인.
- 문서 사이트 CLI 가이드 참고사항에 위 내용이 반영되었는지 확인.
