### PR TITLE
chore(config): add compound-engineering.local.md for review workflows

### DIFF
--- a/compound-engineering.local.md
+++ b/compound-engineering.local.md
@@ -1,0 +1,14 @@
+---
+review_agents: [code-simplicity-reviewer, security-sentinel, performance-oracle, architecture-strategist]
+plan_review_agents: [code-simplicity-reviewer, architecture-strategist]
+---
+
+# Review Context
+
+Add project-specific review instructions here.
+These notes are passed to all review agents during /workflows:review and /workflows:work.
+
+Examples:
+- "Rust crates/hwp-core is the core parser — extra scrutiny on spec compliance and memory safety"
+- "NAPI-RS and Craby bindings — check cross-platform and FFI boundaries"
+- "Snapshot tests (insta) are the source of truth for JSON/HTML output — avoid breaking fixtures"


### PR DESCRIPTION
# chore/compound-engineering-setup

## Purpose

Add project-level configuration for Compound Engineering review workflows (`/workflows:review`, `/workflows:work`) so that agents and review context are defined in one place.

## Work content

- **Added** `compound-engineering.local.md` at repository root with:
  - `review_agents`: code-simplicity-reviewer, security-sentinel, performance-oracle, architecture-strategist
  - `plan_review_agents`: code-simplicity-reviewer, architecture-strategist
  - **Review Context** section with project-specific notes (hwp-core, NAPI-RS/Craby, snapshot tests)

No code or tests were changed. This is configuration only.

## How to test

- Confirm the file exists and frontmatter is valid YAML.
- Optionally run `/setup` again to reconfigure or switch stack (e.g. TypeScript).

## Additional info

- General stack was chosen because the repo mixes Rust (`crates/hwp-core`) and JS/TS (Bun, NAPI-RS). To add TypeScript-focused reviewers later, re-run setup and choose TypeScript.
