### PR TITLE
chore(config): heartbeat 테스트 머신 규칙 정리

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -1,27 +1,31 @@
-# Heartbeat — hwp/core 리팩터 머신 (5분 주기)
+# Heartbeat — hwp-core 테스트 코드 작성 머신 (5분 주기)
 
 이 파일을 읽고 아래 지시대로 **한 턴**에 수행하세요.  
 할 일이 없으면 `HEARTBEAT_OK` 만 답하세요.
 
-**대상:** 이 워크스페이스 **hwpjs** — 특히 **crates/hwp-core** 리팩터링.
+**대상:** 이 워크스페이스 **hwpjs** — 특히 **crates/hwp-core** 테스트 코드 작성.
 
 ---
 
 ## 매 턴 순서
 
-1. **리팩터 작업 1개**  
-   `crates/hwp-core` 안에서 한 가지 리팩터를 진행 (가독성, 구조 정리, 명세 정합성, 경고 제거 등).  
-   변경 범위는 작게 유지.  
-   **우선 후보:** 아래 "리팩터 후보"가 남아 있으면 그중 하나를 선택해 진행.
+1. **시작 브랜치**  
+   **항상 main에서 작업 시작.** 현재 브랜치가 `main`이 아니면 `git checkout main` 후 진행.  
+   (이전 턴에서 PR 올린 브랜치에 머물러 있으면 main으로 돌아온 뒤 다음 작업 진행.)
 
-2. **빌드**  
+2. **테스트 작성 작업 1개**  
+   `crates/hwp-core` 안에서 한 가지 테스트 작업을 진행 (단위 테스트 추가, 스냅샷 테스트 추가, 엣지 케이스 보강, 커버리지 확대 등).  
+   변경 범위는 작게 유지.  
+   **우선 후보:** 아래 "테스트 작성 후보"가 남아 있으면 그중 하나를 선택. **MEMORY.md의 "테스트 PR 기록"을 보고 이미 올린 PR과 겹치지 않게** 다른 세부 작업을 선택해 진행.
+
+3. **빌드**  
    프로젝트 루트에서:
    ```bash
    cd /Users/yoonhb/Documents/workspace/hwpjs && cargo build -p hwp-core
    ```
    실패하면 이 턴에서 커밋하지 말고 원인 정리 후 종료.
 
-3. **테스트 및 스냅샷**  
+4. **테스트 및 스냅샷**  
    ```bash
    cd /Users/yoonhb/Documents/workspace/hwpjs && cargo test -p hwp-core
    ```
@@ -35,33 +39,35 @@
      ```
      (또는 `bun run test:rust:snapshot:review` — 워크스페이스 전체)
    - 대화형으로 각 변경을 **accept**(의도한 개선) 또는 **reject**(회귀) 선택. reject 시 저장된 스냅샷은 그대로 두고, 코드만 원복한 뒤 턴 종료.
-   - **의도한 개선**이면 accept 후 4단계(커밋/푸시 또는 PR) 진행. **회귀**로 판단되면 reject 하고 코드 원복 후 턴 종료.
+   - **의도한 개선**이면 accept 후 5단계(커밋·브랜치·PR) 진행. **회귀**로 판단되면 reject 하고 코드 원복 후 턴 종료.
    - 한 턴에서 스냅샷을 자동 전부 accept 하지 말 것 (`cargo insta review --accept` 사용 금지).
 
-4. **커밋 및 푸시 (조건 충족 시에만)**  
+5. **커밋·브랜치·PR (조건 충족 시에만)**  
    - 빌드·테스트 통과  
    - 스냅샷: 변화 없음 또는 의도한 개선만 accept함  
-   → 커밋까지 진행. **단, 이번 턴에서 스냅샷이 변경된 경우** main 푸시 대신 **PR**로 올리기.
+   → **테스트 코드는 항상 별도 브랜치로 PR.** main에 직접 푸시하지 않음.
 
    ```bash
    cd /Users/yoonhb/Documents/workspace/hwpjs
    git status
    # 변경 있으면:
    git add -A
-   git commit -m "refactor(core): <한 줄 요약>"
+   git commit -m "test(core): <한 줄 요약>"
 
-   # 스냅샷이 바뀌지 않았으면: main 푸시
-   # git push origin main
-
-   # 스냅샷이 바뀌었으면: 브랜치 푸시 후 gh로 PR 생성
-   # git checkout -b refactor/<짧은-설명>
-   # git push -u origin refactor/<짧은-설명>
-   # gh pr create --base main --title "refactor(core): <한 줄 요약>" --body "스냅샷 변경 포함. 리뷰 후 머지."
+   # 항상 브랜치 생성 후 푸시·PR
+   git checkout -b test/<짧은-설명>
+   git push -u origin test/<짧은-설명>
+   gh pr create --base main --title "test(core): <한 줄 요약>" --body "테스트 추가/보강. 리뷰 후 머지."
    ```
 
-   커밋 메시지는 `commit-rules.md` 형식 (refactor(core): …).
+   커밋 메시지는 `commit-rules.md` 형식 (test(core): …).
 
-5. **응답**  
+6. **PR 기록 및 main 복귀**  
+   - PR 생성 후 **MEMORY.md**의 "테스트 PR 기록" 섹션에 이번 PR을 추가 (날짜, 브랜치, PR 번호/제목, 작업 요약). 겹치지 않게 하기 위함.
+   - **main으로 체크아웃:** `git checkout main`  
+   → 다음 턴은 항상 main에서 새 작업을 시작.
+
+7. **응답**  
    위까지 처리한 뒤 `HEARTBEAT_OK` 또는 이번 턴 요약을 보내세요.
 
 ---
@@ -70,25 +76,29 @@
 
 - 빌드/테스트 실패한 상태에서 커밋·푸시하지 않기.
 - 스냅샷 회귀가 있으면 그대로 커밋하지 말고 원복 후 턴 종료.
-- **코드 변경으로 스냅샷이 바뀐 경우** main에 직접 푸시하지 말고, 브랜치 푸시 후 PR로 올리기.
+- **테스트 코드 커밋을 main에 직접 푸시하지 않기.** 항상 별도 브랜치 → PR.
+- PR 올린 뒤 main으로 체크아웃하지 않고 다음 작업을 이어가기 (다음 턴은 반드시 main에서 시작).
+- MEMORY.md에 PR 기록 없이 같은 유형 작업을 반복해 PR 겹치게 하기.
 
 ---
 
-## 리팩터 후보
+## 테스트 작성 후보
 
 할 일이 없을 때 아래에서 **한 턴에 하나** 골라 진행. 끝난 항목은 목록에서 제거해 두기.
 
-- **Clippy 경고 제거**: `cargo clippy -p hwp-core -- -W clippy::all` 로 확인 후, `doc_lazy_continuation`(doc 들여쓰기), `useless_conversion`(`.map_err(HwpError::from)?` → `?`), `redundant_closure` 등 수정. `cargo clippy --fix --lib -p hwp-core` 로 자동 수정 가능한 것부터 적용.
-- **`#[allow(dead_code)]` 정리**: `table.rs`, `line_segment.rs`, `border_fill.rs`, `ctrl_header/caption.rs` 등 — 해당 코드 사용처 추가 또는 미사용 코드 제거 후 allow 제거.
-- **긴 함수 분리**: `bodytext/mod.rs`의 `parse_record_from_tree` 등 100줄 넘는 match/블록은 태그별로 헬퍼 함수로 쪼개기.
-- **중복 로직 추출**: 파싱/렌더링에서 반복되는 패턴을 공통 함수나 모듈로 묶기.
-- **명세 정합성**: 스펙 문서(`documents/docs/spec/`, `.cursor/skills/hwp-spec/`)와 필드명·주석·자료형 맞추기.
-- **TODO 주석 정리**: `viewer/core`, `viewer/html/ctrl_header` 등에 있는 TODO를 백로그(`documents/docs/backlog/`) 항목과 연결하거나 주석 보강.
+- **단위 테스트 추가**: `document/`, `viewer/core/`, `viewer/html/`, `viewer/markdown/` 등 모듈별로 `#[cfg(test)] mod tests` 또는 `tests/` 통합 테스트 추가. 파싱/렌더링 헬퍼, 경계값, 에러 경로 등.
+- **스냅샷 테스트 추가**: `tests/fixtures/`에 새 HWP 추가 후 `snapshot_tests.rs`에 JSON/HTML/MD 스냅샷 케이스 추가. `common::find_fixture_file()` 사용.
+- **엣지 케이스 보강**: 빈 문서, 최소 필드, 잘못된 바이트 등 예외/경계 입력에 대한 테스트 추가.
+- **기존 fixture 커버리지 확대**: 이미 있는 fixture에 대해 아직 스냅샷이 없는 출력 형식(JSON/HTML/MD) 케이스 추가.
+- **뷰어 단위 테스트**: `viewer/html/pagination.rs` 등 이미 `#[cfg(test)]`가 있는 곳 보강, 또는 다른 viewer 서브모듈에 단위 테스트 추가.
+- **문서/스펙 기반 검증**: 스펙(`documents/docs/spec/`, `.cursor/skills/hwp-spec/`)과 일치하는지 검증하는 테스트(필드 존재, 자료형 등) 추가.
+- **백로그 연동**: `documents/docs/backlog/`에 테스트 관련 항목이 있으면 해당 범위 테스트 작성.
 
 ---
 
 ## 참고
 
 - 스냅샷 경로: `crates/hwp-core/tests/snapshots/`
+- Fixtures 경로: `crates/hwp-core/tests/fixtures/`
 - 스냅샷 검토(accept/reject): `cargo insta review -p hwp-core`
 - 명세/가이드: `AGENTS.md`, `documents/docs/spec/`, `.cursor/skills/hwp-spec/`

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -4,40 +4,16 @@ Long-term memory and context for this workspace. Update this file with decisions
 
 ---
 
-## Recent Work (2025-06)
+## 테스트 PR 기록
 
-### Refactoring Tasks Completed
+하트비트에서 테스트 코드 PR을 올릴 때마다 아래에 한 줄씩 추가. 같은 유형 작업이 겹치지 않도록 참고.
 
-1. **Fixed field_reassign_with_default warning** (pagination.rs)
-   - Removed `ParaHeader::default()` call and inlined struct initialization
-   - This eliminated the Clippy warning about assigning to a default instance immediately after creation
-   - No snapshot changes; all tests pass
+| 날짜       | 브랜치            | PR 제목/번호 | 작업 요약 |
+| ---------- | ------------------ | ------------ | --------- |
+| (예시) 2026-02-24 | test/unit-viewer-html | test(core): add viewer/html unit tests | 뷰어 HTML 단위 테스트 추가 |
 
-2. **Added #[allow(dead_code)] to find_headerfooter_file** (common.rs)
-   - Suppressed false positive Clippy warning for a helper function used in tests
-   - The function is called in snapshot_tests.rs at lines 343 and 520
-   - Clippy can't see the usage at compile time due to how `use common::*;` imports work
-   - No snapshot changes; all tests pass
+---
 
-### Current State
-
-- All tests passing (16 passed, 0 failed)
-- No Clippy warnings on hwp-core code (only workspace configuration warnings)
-- Clean working tree
-- Working on hwpjs/rp-core refactoring as per HEARTBEAT.md
-
-### Dead Code Annotations
-
-There are three intentional `#[allow(dead_code)]` annotations:
-
-1. **caption.rs** - Two functions (`parse_caption`, `parse_caption_12bytes`) with TODO comments:
-   - "// TODO: enable and use when parsing captions from HWPTAG_CAPTION tag"
-   - Marked for future use when HWPTAG_CAPTION tag parsing is implemented
-
-2. **line_segment.rs** - One field (`affect_line_spacing`) with comment:
-   - "(현재 미사용, 향후 기능)" (currently unused, for future features)
-   - Object_common attribute: affect line spacing
-
-These annotations are intentional and documented, requiring no action at this time.
+(비어 있음)
 
 ---

--- a/docs/plans/2026-02-24-refactor-agent-docs-harness-engineering-plan.md
+++ b/docs/plans/2026-02-24-refactor-agent-docs-harness-engineering-plan.md
@@ -1,0 +1,109 @@
+---
+title: refactor: 에이전트 문서 Harness Engineering 스타일 리팩터링
+type: refactor
+status: active
+date: 2026-02-24
+---
+
+# 에이전트 문서 Harness Engineering 스타일 리팩터링
+
+## Overview
+
+OpenAI의 [Harness Engineering](https://openai.com/index/harness-engineering/) 글을 기준으로, 현재 단일 대형 `AGENTS.md`(약 813줄)를 **진입용 목차(~100줄)** 로 줄이고, 저장소 지식을 **구조화된 `docs/`** 를 시스템 오브 레코드로 두는 방식으로 리팩터링한다. 에이전트는 짧은 고정 진입점만 읽고, 필요 시 "다음에 볼 문서" 링크로 progressive disclosure 하도록 한다.
+
+## Problem Statement / Motivation
+
+- **현재**: `AGENTS.md` 한 파일에 에이전트 진입 규칙, 프로젝트 구조, 기술 스택, 아키텍처, 개발 가이드라인, 패키지 상세, 뷰어 아키텍처, 커밋 규칙 등이 모두 포함되어 있음(~813줄).
+- **Harness에서 지적한 문제**:
+  - 한 덩어리 매뉴얼은 검증·신선도·소유권·교차 링크가 어려워 **drift 불가피**
+  - 모노리식 매뉴얼은 **쉽게 낡고**, 에이전트는 무엇이 아직 유효한지 구분하기 어려움
+  - **"전부 중요" = "아무것도 중요하지 않음"** → 에이전트가 의도적 탐색 대신 국소 패턴 매칭에 의존
+  - **컨텍스트가 희소** → 긴 지시 파일이 태스크·코드·관련 문서를 밀어내어 핵심 제약을 놓치거나 잘못된 제약에 최적화할 수 있음
+- **목표**: AGENTS.md를 "백과사전"이 아니라 **"목차"** 로 두고, 상세는 `docs/` 등 구조화된 경로에 두어 검증·유지보수·progressive disclosure가 가능하게 함.
+
+## Proposed Solution
+
+### 1. AGENTS.md를 진입용 ToC(~100줄)로 축소
+
+**AGENTS.md에 남길 내용:**
+
+- OpenClaw hwpjs 에이전트 소개 (이 워크스페이스용)
+- **세션 시작 시**: `SOUL.md`, `USER.md` 읽기; 필요 시 `memory/YYYY-MM-DD.md`, `MEMORY.md` 참고
+- **하트비트 시**: `HEARTBEAT.md` 읽고 적힌 순서대로만 실행
+- **언어·도구**: 한국어, 담백·결과 위주; 파일/명령 적극 사용, 파괴적 명령은 사용자 확인 후
+- **프로젝트 한 줄 요약**: HWP 파싱 라이브러리, Rust 핵심 + Node/RN 래퍼
+- **다음에 볼 문서(Where to look next)** 블록:
+  - **스펙/레퍼런스**: `documents/docs/spec/` (특히 `hwp-5.0.md`), `.cursor/skills/hwp-spec/`
+  - **설계/아키텍처**: `docs/design/` (또는 루트 `architecture.md`, `folder-structure.md` 링크)
+  - **실행 계획**: `docs/plans/`, `documents/plans/`
+  - **로드맵·백로그**: `documents/docs/roadmap/`, `documents/docs/backlog/`
+  - **프로세스(커밋/린트/테스트)**: `commit-rules.md`, `lint-rules.md`, (선택) `docs/process/testing.md`
+  - **패키지 상세**: `docs/design/` 또는 documents 가이드 링크
+
+### 2. 저장소 지식 구조: `docs/` as system of record
+
+Harness 예시에 맞춰, 루트 `docs/` 아래를 단일 진입 체계로 둔다.
+
+| 목적 | 경로 | 비고 |
+|------|------|------|
+| 설계 문서 | `docs/design/` | architecture, folder-structure, viewer-architecture, (선택) packages-hwpjs |
+| 실행 계획 | `docs/plans/` | 기존 `docs/plans/` 유지; `documents/plans/`는 README에서 링크로 통합 |
+| 프로세스 | `docs/process/` (선택) | 테스트/빌드/린트 상세 |
+| 레퍼런스 | `documents/docs/spec/` | 기존 유지, AGENTS.md에서 경로만 안내 |
+| 제품/로드맵·백로그 | `documents/docs/roadmap/`, `documents/docs/backlog/` | 기존 유지 |
+
+**AGENTS.md에서 옮길 내용 → 대상 파일:**
+
+- 프로젝트 구조 트리 → `docs/design/folder-structure.md` (또는 기존 루트 `folder-structure.md`를 `docs/design/`으로 이동/복사 후 링크)
+- 기술 스택 상세 → 기존 `tech-stack.md` 유지, AGENTS.md는 한 줄 링크
+- 아키텍처 설계 전체 → `docs/design/architecture.md` (기존 `architecture.md` 이전 또는 병합)
+- 워크스페이스 설정(Bun/Cargo) → `docs/design/architecture.md` 또는 `docs/process/workspace.md`
+- 개발 가이드라인(함수 파라미터, HWP 타입, 테스트 규칙, 빌드, 린트) → `docs/process/` 또는 기존 `commit-rules.md`/`lint-rules.md` 확장·링크
+- 패키지별 상세(crates/hwp-core, packages/hwpjs, examples, documents) → `docs/design/packages.md` 또는 documents 가이드와 정리 후 한 곳
+- packages/hwpjs 구조와 원리(이중 빌드, exports, 패키징) → `docs/design/packages-hwpjs.md`
+- 뷰어 아키텍처 및 확장 계획 → `docs/design/viewer-architecture.md`
+- 주의사항 → ToC에 한두 줄 + 상세는 해당 design/process 문서로
+
+### 3. Progressive disclosure
+
+- 에이전트는 항상 **짧은 AGENTS.md** 만으로 "누가, 언제, 무엇을 읽는지"와 "다음에 어디를 볼지"를 알 수 있게 함.
+- 설계·실행·프로세스 상세는 **필요할 때만** 링크를 따라가도록 안내.
+
+### 4. 기계적 검증(추후 선택)
+
+- `AGENTS.md` 줄 수 상한(예: 120줄) 린트
+- `docs/design/`, `docs/plans/` 내부 링크 유효성 검사
+- AGENTS.md에 명시된 경로가 실제 파일/디렉터리인지 CI에서 검사
+
+## Technical Considerations
+
+- **기존 파일 보존**: `SOUL.md`, `USER.md`, `HEARTBEAT.md`, `MEMORY.md`, `memory/` 는 위치·역할 유지. AGENTS.md에서는 요약·링크만 제공.
+- **중복 제거**: 루트 `architecture.md`, `folder-structure.md`, `commit-rules.md`, `lint-rules.md` 가 이미 있으므로, 옮길 때 복사가 아닌 **이동 또는 링크 통합**으로 정리하면 유지보수 부담을 줄일 수 있음.
+- **documents/ 와 docs/ 역할**: Rspress 문서 사이트(`documents/docs/`)와 스펙/로드맵/백로그는 그대로 두고, "에이전트용 설계·실행 계획"은 루트 `docs/` 에 두어 Cursor/에이전트 컨텍스트에서 찾기 쉽게 함.
+- **.cursor 연동**: `.cursor/commands/commit.md`, `pr.md`, `.cursor/agents/`, `.cursor/skills/` 는 기존대로 두고, AGENTS.md와 새 `docs/` 경로만 수정·추가.
+
+## Acceptance Criteria
+
+- [ ] `AGENTS.md` 가 약 100줄 이하(권장 상한 120줄)로 축소되어, 진입 규칙 + "다음에 볼 문서" 링크만 포함한다.
+- [ ] 설계 문서가 `docs/design/` (또는 명시된 대안)에 존재하고, AGENTS.md에서 링크로 참조된다.
+- [ ] 실행 계획 진입점이 `docs/plans/` (및 필요 시 `documents/plans/` 링크)로 명확히 안내된다.
+- [ ] 스펙·로드맵·백로그·커밋/린트 규칙 경로가 AGENTS.md에 한 줄씩 명시된다.
+- [ ] 기존 에이전트 동작(세션 시작 시 SOUL/USER/memory/MEMORY, 하트비트 시 HEARTBEAT 순서)은 변경 없이 유지된다.
+- [ ] (선택) `docs/process/` 또는 기존 루트 문서에 테스트/빌드/린트 상세가 정리되어 AGENTS.md와 중복이 없다.
+
+## Success Metrics
+
+- 에이전트가 긴 매뉴얼 대신 짧은 진입점 + 필요 시 링크만 읽어도 태스크를 수행할 수 있음.
+- 설계·실행·프로세스 변경 시 한 곳만 수정하면 되어 drift가 줄어듦.
+- 추후 린트/CI로 문서 신선도·교차 링크를 기계적으로 검증할 수 있는 구조가 됨.
+
+## Dependencies & Risks
+
+- **의존성**: 없음. 문서/디렉터리 이동·편집만으로 수행 가능.
+- **리스크**: AGENTS.md 축소 과정에서 일부 규칙이 빠지면 에이전트 동작이 달라질 수 있음. 이전 버전(또는 분리된 design/process 문서)에 반드시 옮겨 적고, 리팩터 후 한 번 하트비트/세션 시나리오를 확인하는 것이 좋음.
+
+## References & Research
+
+- **Harness Engineering**: [Harness engineering: leveraging Codex in an agent-first world](https://openai.com/index/harness-engineering/) — AGENTS.md as table of contents, structured docs/ as system of record, progressive disclosure.
+- **내부 연구**: repo-research-analyst·learnings-researcher 에이전트 실행 결과 요약(AGENTS.md 812줄, 섹션 목록, docs/ 구조 제안, docs/solutions 없음).
+- **기존 문서**: `AGENTS.md`, `architecture.md`, `folder-structure.md`, `commit-rules.md`, `HEARTBEAT.md`, `documents/docs/spec/`, `documents/plans/`, `docs/plans/`.


### PR DESCRIPTION
# chore(config): heartbeat 테스트 머신 규칙 정리

## Purpose

하트비트가 테스트 코드 작성 머신으로 동작할 때, 테스트 작업은 항상 별도 브랜치·PR로만 올리도록 하고, PR 후에는 main으로 복귀해 다음 턴을 main에서 시작하며, 작업한 PR을 MEMORY에 기록해 겹치지 않게 하기 위함.

## Work content

- **HEARTBEAT.md**
  - 1단계: 매 턴 **시작 브랜치** — 항상 main에서 시작하도록 명시. main이 아니면 `git checkout main` 후 진행.
  - 2단계: 테스트 작성 시 **MEMORY.md의 "테스트 PR 기록"**을 참고해 이미 올린 PR과 겹치지 않게 세부 작업 선택.
  - 5단계: 테스트 커밋은 **항상** 별도 브랜치 생성 → 푸시 → PR. main 직접 푸시 제거.
  - 6단계: **PR 기록 및 main 복귀** — PR 생성 후 MEMORY.md에 기록, `git checkout main`으로 복귀.
  - 하지 말 것: 테스트 커밋 main 푸시 금지, PR 후 main 미복귀 금지, MEMORY 미기록으로 중복 PR 금지.
- **MEMORY.md**
  - "테스트 PR 기록" 섹션 추가. 표(날짜 | 브랜치 | PR 제목/번호 | 작업 요약)와 예시 행으로 하트비트에서 PR 올릴 때마다 한 줄씩 추가해 겹치지 않게 참고.
- **docs/plans**
  - 관련 플랜 문서 포함 (이번 규칙 변경과 함께 커밋된 문서).

테스트는 코드 변경만 있고, 이번 PR은 설정/문서 변경만 포함됩니다.

## How to test

- HEARTBEAT.md를 읽고 1·2·5·6단계와 "하지 말 것"이 위 내용대로인지 확인.
- MEMORY.md에 "테스트 PR 기록" 표가 있는지 확인.
