### PR TITLE
test(core): add viewer/html page module unit tests

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -19,6 +19,7 @@ Long-term memory and context for this workspace. Update this file with decisions
 | 2026-02-25 | test/viewer-html-pagination-unit-tests | test(core): add viewer/html pagination module unit tests (PR #29) | PaginationContext/PaginationResult 구조체, PageBreakReason 열거형, 컨텍스트 초기화 및 결과 검증 테스트 추가 |
 | 2026-02-25 | test/viewer-html-render-module-unit-tests | test(core): add viewer/html render module unit tests (PR #30) | TextStyles 기본값, 렌더러 메서드 (render_text, render_bold, render_italic, render_underline, render_strikethrough, render_superscript, render_subscript), 엣지 케이스 및 경계값 테스트 14개 추가 |
 | 2026-02-25 | test/viewer-html-text-module-unit-tests | test(core): add viewer/html text module unit tests (PR #31) | ParaText, ParaCharShape 레코드 처리 검증. CharShapeInfo 필드(shape_id, position) 및 형 변환(usize → u32) 8개 단위 테스트 추가 |
+| 2026-02-25 | test/viewer-html-page-module-unit-tests | test(core): add viewer/html page module unit tests (PR #32) | HtmlPageBreak 구조체 및 Display impl 테스트, HTML 포맷팅 태그 검증 (5개 테스트), 코드 정리 (text_test/styles_test 경고 수정) |
 
 ---
 


### PR DESCRIPTION
테스트 추가/보강. 페이지 모듈 HtmlPageBreak 구조체 및 Display 구현에 대한 단위 테스트를 추가함.

- new() 메서드 생성 및 기본 HTML 생성 검증
- Display impl 렌더링 검증 (<span></span> 태그)
- 구조체 인스턴스화 및 동일성 검증
- HTML 포맷팅 검증 (태그 구조)
- 추가: text_test 및 styles_test 내 불필요한 import/변수 경고 수정

- 5개 테스트 케이스, 모두 통과
- 코드 정리: text_test.rs에서 unused char_shapes 제거, styles_test.rs에서 불필요한 use super::* 제거

리뷰 후 머지.