### PR TITLE
feat(styles): CharShape 음영 색(shading_color) CSS background-color 렌더링 추가

### DIFF
--- a/crates/hwp-core/src/viewer/html/styles.rs
+++ b/crates/hwp-core/src/viewer/html/styles.rs
@@ -152,6 +152,17 @@ pub fn generate_css_styles(document: &HwpDocument) -> String {
             css.push_str(&format!("letter-spacing:{:.2}em;", letter_spacing_em));
         }
 
+        // 음영 색 (background-color) / Shading color
+        let shading = &char_shape.shading_color;
+        if !(shading.r() == 255 && shading.g() == 255 && shading.b() == 255) {
+            css.push_str(&format!(
+                "background-color:#{:02X}{:02X}{:02X};",
+                shading.r(),
+                shading.g(),
+                shading.b()
+            ));
+        }
+
         css.push_str("\n}\n");
     }
 

--- a/crates/hwp-core/tests/snapshots/selfintroduce.html
+++ b/crates/hwp-core/tests/snapshots/selfintroduce.html
@@ -82,7 +82,7 @@ body {margin:0;padding-left:0;padding-right:0;padding-bottom:0;padding-top:2mm;}
   font-size:16pt;color:rgb(0,0,0);font-family:"맑은 고딕";
 }
 .cs6 {
-  font-size:16pt;color:rgb(0,0,0);font-family:"맑은 고딕";
+  font-size:16pt;color:rgb(0,0,0);font-family:"맑은 고딕";background-color:#FFD700;
 }
 .cs7 {
   font-size:16pt;color:rgb(0,0,0);font-family:"맑은 고딕";letter-spacing:-0.04em;

--- a/crates/hwp-core/tests/snapshots/snapshot_tests__selfintroduce_html.snap
+++ b/crates/hwp-core/tests/snapshots/snapshot_tests__selfintroduce_html.snap
@@ -86,7 +86,7 @@ body {margin:0;padding-left:0;padding-right:0;padding-bottom:0;padding-top:2mm;}
   font-size:16pt;color:rgb(0,0,0);font-family:"맑은 고딕";
 }
 .cs6 {
-  font-size:16pt;color:rgb(0,0,0);font-family:"맑은 고딕";
+  font-size:16pt;color:rgb(0,0,0);font-family:"맑은 고딕";background-color:#FFD700;
 }
 .cs7 {
   font-size:16pt;color:rgb(0,0,0);font-family:"맑은 고딕";letter-spacing:-0.04em;


### PR DESCRIPTION
## Summary

CharShape의 `shading_color` 속성이 HTML CSS 클래스 생성 시 `background-color`로 변환되지 않아, 음영 처리된 텍스트(예: `selfintroduce.hwp`의 "이름")의 배경색이 렌더링되지 않던 문제를 수정합니다.

## 문제 상세

### 현상
- `fixtures/selfintroduce.HTML`(한컴오피스 기준 출력)에서는 `.cs6` 클래스에 `background-color:#FFD700` (노란색 음영)이 포함되어 있음
- `snapshots/selfintroduce.html`(hwpjs 출력)에서는 `.cs6` 클래스에 `background-color` 속성이 누락되어 "이름" 텍스트에 음영이 표시되지 않음

### 원인
`crates/hwp-core/src/viewer/html/styles.rs`의 `generate_css_styles()` 함수에서 CharShape → CSS 변환 시 다음 속성만 처리하고 있었음:
- ✅ `font-size` (base_size)
- ✅ `color` (text_color)
- ✅ `font-family` (font_ids → face_names)
- ✅ `font-weight` / `font-style` (attributes: bold, italic)
- ✅ `letter-spacing` (letter_spacing)
- ❌ **`background-color` (shading_color) — 누락**

`CharShape` 구조체에는 `shading_color: COLORREF` 필드가 이미 올바르게 파싱되어 있었으나 (`char_shape.rs:128-129`), CSS 출력 단계에서 사용되지 않고 있었음.

### JSON 스냅샷 데이터 확인
```json
// cs6 (shading 적용된 charshape)
"shading_color": { "r": 255, "g": 215, "b": 0 }  // #FFD700 (Gold)

// 다른 cs들 (shading 미적용)
"shading_color": { "r": 255, "g": 255, "b": 255 }  // #FFFFFF (White = 음영 없음)
```

## 변경 사항

### `crates/hwp-core/src/viewer/html/styles.rs`
- CharShape CSS 생성 루프에 `shading_color` → `background-color` 변환 로직 추가
- `shading_color`가 흰색(`#FFFFFF`)이 아닌 경우에만 `background-color` 속성을 출력하여, 불필요한 CSS 속성 생성 방지

```rust
// 음영 색 (background-color) / Shading color
let shading = &char_shape.shading_color;
if !(shading.r() == 255 && shading.g() == 255 && shading.b() == 255) {
    css.push_str(&format!(
        "background-color:#{:02X}{:02X}{:02X};",
        shading.r(), shading.g(), shading.b()
    ));
}
```

### `crates/hwp-core/tests/snapshots/selfintroduce.html` & `.snap`
- `.cs6` 클래스에 `background-color:#FFD700` 추가 반영

**Before:**
```css
.cs6 {
  font-size:16pt;color:rgb(0,0,0);font-family:"맑은 고딕";
}
```

**After:**
```css
.cs6 {
  font-size:16pt;color:rgb(0,0,0);font-family:"맑은 고딕";background-color:#FFD700;
}
```

## 스펙 근거

HWP 5.0 스펙 문서 `표 33 (글자 모양)`:
| 필드명 | 타입 | 설명 |
|--------|------|------|
| 음영 색 | COLORREF | 글자 배경에 적용되는 음영(shading) 색상 |

## Test plan

- [x] `cargo build` 정상 완료
- [x] `cargo test --test snapshot_tests` 18개 테스트 전체 통과
- [x] `selfintroduce.html` 스냅샷에 `background-color:#FFD700` 정상 출력 확인
- [x] fixture(`selfintroduce.HTML`)의 `.cs6` 클래스와 snapshot의 `.cs6` 클래스 CSS 속성 일치 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)