### PR TITLE
fix: HWPX 렌더링 버그 수정 — underline/strikeout/내어쓰기

### DIFF
--- a/crates/hwp-core/src/viewer/doc_html/layout_text.rs
+++ b/crates/hwp-core/src/viewer/doc_html/layout_text.rs
@@ -187,20 +187,30 @@ fn apply_inline_styles(text: &str, cs: &CharShape) -> String {
         result = format!("<em>{}</em>", result);
     }
 
-    // underline: Center(취소선), Bottom/Top(밑줄)
+    // underline: Center(취소선), Bottom/Top(밑줄) — shape이 None이면 무시
     let has_center_underline = cs
         .underline
         .as_ref()
-        .map(|ul| ul.underline_type == hwp_model::types::UnderlineType::Center)
+        .map(|ul| {
+            ul.shape != hwp_model::types::LineType3::None
+                && ul.underline_type == hwp_model::types::UnderlineType::Center
+        })
         .unwrap_or(false);
     if let Some(ref ul) = cs.underline {
-        if ul.underline_type == hwp_model::types::UnderlineType::Bottom {
+        if ul.shape != hwp_model::types::LineType3::None
+            && ul.underline_type == hwp_model::types::UnderlineType::Bottom
+        {
             result = format!("<u>{}</u>", result);
         }
     }
 
-    // strikethrough: strikeout 또는 underline.Center (중복 방지)
-    if cs.strikeout.is_some() || has_center_underline {
+    // strikethrough: strikeout 또는 underline.Center (중복 방지) — shape이 None이면 무시
+    let has_strikeout = cs
+        .strikeout
+        .as_ref()
+        .map(|st| st.shape != hwp_model::types::LineType3::None)
+        .unwrap_or(false);
+    if has_strikeout || has_center_underline {
         result = format!("<s>{}</s>", result);
     }
 

--- a/crates/hwp-core/src/viewer/doc_html/paragraph.rs
+++ b/crates/hwp-core/src/viewer/doc_html/paragraph.rs
@@ -218,11 +218,19 @@ fn build_para_style(para: &Paragraph, resources: &Resources, _options: &DocHtmlO
 
         // 여백
         let indent_hwp = ps.margin.indent.value;
+        let left_hwp = ps.margin.left.value;
         if indent_hwp != 0 {
             let indent_pt = indent_hwp as f64 / 100.0;
             styles.push(format!("text-indent: {:.1}pt", indent_pt));
+            // 음수 indent(내어쓰기)에 left margin이 부족하면 padding-left로 보정
+            if indent_hwp < 0 {
+                let abs_indent = (-indent_hwp) as i32;
+                if left_hwp < abs_indent {
+                    let pad_pt = (abs_indent - left_hwp) as f64 / 100.0;
+                    styles.push(format!("padding-left: {:.1}pt", pad_pt));
+                }
+            }
         }
-        let left_hwp = ps.margin.left.value;
         if left_hwp != 0 {
             let left_pt = left_hwp as f64 / 100.0;
             styles.push(format!("margin-left: {:.1}pt", left_pt));
@@ -384,18 +392,22 @@ fn apply_char_style_html(
         close_tags.insert_str(0, "</i>");
     }
     if let Some(ref ul) = cs.underline {
-        if ul.underline_type == hwp_model::types::UnderlineType::Center {
-            // 가운데줄(Center)은 취소선으로 렌더링
-            open_tags.push_str("<del>");
-            close_tags.insert_str(0, "</del>");
-        } else {
-            open_tags.push_str("<u>");
-            close_tags.insert_str(0, "</u>");
+        if ul.shape != hwp_model::types::LineType3::None {
+            if ul.underline_type == hwp_model::types::UnderlineType::Center {
+                // 가운데줄(Center)은 취소선으로 렌더링
+                open_tags.push_str("<del>");
+                close_tags.insert_str(0, "</del>");
+            } else {
+                open_tags.push_str("<u>");
+                close_tags.insert_str(0, "</u>");
+            }
         }
     }
-    if cs.strikeout.is_some() {
-        open_tags.push_str("<del>");
-        close_tags.insert_str(0, "</del>");
+    if let Some(ref st) = cs.strikeout {
+        if st.shape != hwp_model::types::LineType3::None {
+            open_tags.push_str("<del>");
+            close_tags.insert_str(0, "</del>");
+        }
     }
     if cs.superscript {
         open_tags.push_str("<sup>");

--- a/crates/hwp-core/src/viewer/doc_html/paragraph.rs
+++ b/crates/hwp-core/src/viewer/doc_html/paragraph.rs
@@ -224,7 +224,7 @@ fn build_para_style(para: &Paragraph, resources: &Resources, _options: &DocHtmlO
             styles.push(format!("text-indent: {:.1}pt", indent_pt));
             // 음수 indent(내어쓰기)에 left margin이 부족하면 padding-left로 보정
             if indent_hwp < 0 {
-                let abs_indent = (-indent_hwp) as i32;
+                let abs_indent = -indent_hwp;
                 if left_hwp < abs_indent {
                     let pad_pt = (abs_indent - left_hwp) as f64 / 100.0;
                     styles.push(format!("padding-left: {:.1}pt", pad_pt));

--- a/crates/hwpx-parser/src/header.rs
+++ b/crates/hwpx-parser/src/header.rs
@@ -304,23 +304,31 @@ fn parse_char_shape(
                 b"supscript" => cs.superscript = true,
                 b"subscript" => cs.subscript = true,
                 b"underline" => {
-                    cs.underline = Some(Underline {
-                        underline_type: attr_str(e, b"type")
-                            .map(|s| parse_underline_type(&s))
-                            .unwrap_or_default(),
-                        shape: attr_str(e, b"shape")
-                            .map(|s| parse_line_type3(&s))
-                            .unwrap_or_default(),
-                        color: attr_str(e, b"color").and_then(|s| parse_color(&s)),
-                    });
+                    // type="NONE"이면 밑줄 없음 — underline 설정하지 않음
+                    let ul_type = attr_str(e, b"type");
+                    if ul_type.as_deref() != Some("NONE") {
+                        cs.underline = Some(Underline {
+                            underline_type: ul_type
+                                .map(|s| parse_underline_type(&s))
+                                .unwrap_or_default(),
+                            shape: attr_str(e, b"shape")
+                                .map(|s| parse_line_type3(&s))
+                                .unwrap_or_default(),
+                            color: attr_str(e, b"color").and_then(|s| parse_color(&s)),
+                        });
+                    }
                 }
                 b"strikeout" => {
-                    cs.strikeout = Some(Strikeout {
-                        shape: attr_str(e, b"shape")
-                            .map(|s| parse_line_type3(&s))
-                            .unwrap_or_default(),
-                        color: attr_str(e, b"color").and_then(|s| parse_color(&s)),
-                    });
+                    // shape="NONE"이면 취소선 없음
+                    let st_shape = attr_str(e, b"shape")
+                        .map(|s| parse_line_type3(&s))
+                        .unwrap_or_default();
+                    if st_shape != LineType3::None {
+                        cs.strikeout = Some(Strikeout {
+                            shape: st_shape,
+                            color: attr_str(e, b"color").and_then(|s| parse_color(&s)),
+                        });
+                    }
                 }
                 b"outline" => {
                     cs.outline = Some(


### PR DESCRIPTION
## Summary

HWPX 문서 렌더링 시 발생하는 3가지 버그를 수정합니다.

### 1. underline/strikeout이 모든 텍스트에 적용되는 문제
- HWPX XML에서 `<underline type="NONE" shape="SOLID"/>`처럼 `type="NONE"`인 경우에도 `Some(Underline {...})`로 파싱되어 모든 텍스트에 `<u>` 태그가 적용됨
- `<strikeout shape="NONE"/>`도 마찬가지로 `Some(Strikeout {...})`로 파싱되어 `<del>` 태그 적용
- **수정**: 파서에서 `type="NONE"` / `shape="NONE"`이면 설정하지 않고, 렌더러에서도 `shape=None` 검사 추가

### 2. 음수 text-indent(내어쓰기)로 텍스트 앞부분이 잘리는 문제
- `text-indent: -71.8pt`처럼 음수 indent가 있을 때 `margin-left`가 0이면 첫 줄 텍스트가 컨테이너 밖으로 밀림
- **수정**: `abs(indent) > left`일 때 차액만큼 `padding-left` 보정 추가

## 변경 파일
- `crates/hwpx-parser/src/header.rs` — underline/strikeout 파싱 조건 추가
- `crates/hwp-core/src/viewer/doc_html/paragraph.rs` — shape=None 검사 + padding-left 보정
- `crates/hwp-core/src/viewer/doc_html/layout_text.rs` — shape=None 검사

## Test plan
- [ ] HWPX 파일에서 불필요한 밑줄/취소선이 사라지는지 확인
- [ ] 실제 밑줄이 있는 텍스트(`type="BOTTOM"`)는 정상 렌더링되는지 확인
- [ ] 내어쓰기(hanging indent) 텍스트 앞부분이 잘리지 않는지 확인
- [ ] 기존 HWP 파일 렌더링에 영향 없는지 확인